### PR TITLE
feat: fix retrieving of CCYs

### DIFF
--- a/src/Coinbase.lua
+++ b/src/Coinbase.lua
@@ -68,23 +68,31 @@ function RefreshAccount (account, since)
   balances = queryPrivate("accounts")
 
   for key, value in pairs(balances) do
-    prices = queryPublic("exchange-rates", "?currency=" .. value["currency"]["code"])
+
+    local qty = value["balance"]["amount"]
+    local ccy = value["currency"]["code"]
+
     if value["type"] == "fiat" then
       s[#s+1] = {
         name = value["currency"]["name"],
         market = market,
         currency = currency,
-        amount = value["balance"]["amount"]
+        amount = qty
       }
     else
-      s[#s+1] = {
-        name = value["currency"]["name"],
-        market = market,
-        currency = nil,
-        quantity = value["balance"]["amount"],
-        amount = value["native_balance"]["amount"],
-        price = prices["rates"][value["native_balance"]["currency"]]
-      }
+      if tonumber(qty) > 0 then
+        
+        prices = queryPublic("exchange-rates", "?currency=" .. ccy)
+
+        s[#s+1] = {
+          name = value["currency"]["name"],
+          market = market,
+          currency = nil,
+          quantity = qty,
+          amount = value["native_balance"]["amount"],
+          price = prices["rates"][value["native_balance"]["currency"]]
+        }
+      end
     end
   end
 
@@ -128,3 +136,4 @@ function queryPublic(method, query)
 
   return json:dictionary()["data"]
 end
+

--- a/src/Coinbase.lua
+++ b/src/Coinbase.lua
@@ -74,18 +74,18 @@ function RefreshAccount (account, since)
 
     if value["type"] == "fiat" then
       s[#s+1] = {
-        name = value["currency"]["name"],
+        name = value["currency"]["name"] .. " (" .. ccy .. ")",
         market = market,
         currency = currency,
         amount = qty
       }
     else
-      if tonumber(qty) > 0 then
+      if tonumber(qty) ~= 0 then
         
         prices = queryPublic("exchange-rates", "?currency=" .. ccy)
 
         s[#s+1] = {
-          name = value["currency"]["name"],
+          name = value["currency"]["name"] .. " (" .. ccy .. ")",
           market = market,
           currency = nil,
           quantity = qty,
@@ -136,4 +136,3 @@ function queryPublic(method, query)
 
   return json:dictionary()["data"]
 end
-


### PR DESCRIPTION
Since XRP is now also not queryable (for me at least) i've taken a different approach. only query for a rate when the qty in coinbase > 0.


Remove all balances that are zero in Coinbase. This way the currency codes for such balances (atm. XRP and REP-V2) are not queried at all.
besides this the change also removes tons of tokens i do not own from my moneymoney coinbase balance. 

removed signature as a am not able to compute it myself